### PR TITLE
Update modbusSlave.cpp

### DIFF
--- a/arduino-modbus-slave/modbusSlave.cpp
+++ b/arduino-modbus-slave/modbusSlave.cpp
@@ -325,14 +325,22 @@ void modbusSlave::run(void)
 	//if a reply was generated
 	if(_len)
 	{
+		digitalWrite(8,HIGH);
+		
 		int i;
 		//send the reply to the serial UART
-		//Senguino doesn't support a bulk serial write command....
+		//Quantity of registers must respect Modbus limit
+		// Tested with function 3 and 125 registers (master = ModbusDoctor)
 		for(i = 0 ; i < _len ; i++)
+		{
 			Serial.write(_msg[i]);
+			delay(1);
+		}
 		//free the allocated memory for the reply message
 		free(_msg);
 		//reset the message length
 		_len = 0;
+		
+		digitalWrite(8,LOW);
 	}
 }


### PR DESCRIPTION
To use RS-485 TTL MODBUS from LC Electronics, I must add "digitalWrite(8, HIGH);" before int i; when a reply is generated and a delay of 1 millisecond after each Serial.write and finally "digitalWrite(8, LOW);" just after _len = 0; . 8 pinMode of Arduino MEGA2560 is configured in output mode in setup and initialized at LOW. To use with Serial 1, i have modified each Serial. by Serial1. (you can do then same with serial 2 or 3). I have tested that with read holding registers function with 125 register in cycle mode of ModdusDoctor). I am sorry, my English is not very good.